### PR TITLE
style: 修改日期格式为ISO标准

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -8,8 +8,8 @@ since = 2017
 customText = '<a href="https://debuginn.com">主页</a>&nbsp;·&nbsp<a href="https://blog.debuginn.com/">博客</a>&nbsp;·&nbsp<a href="https://photo.debuginn.com">摄影</a>&nbsp;·&nbsp<a href="/project/">项目</a>&nbsp;·&nbsp<a href="/about/">关于</a>'
 
 [dateFormat]
-published = "2023/10/15"
-lastUpdated = "2023/10/15 15:04 MST"
+published = "2023-10-15"
+lastUpdated = "2023-10-15 15:04 MST"
 
 [sidebar]
 emoji = "🌏"


### PR DESCRIPTION
将 `published` 和 `lastUpdated` 的日期格式从 "2023/10/15" 改为 "2023-10-15"，以符合ISO 8601标准，提高一致性和可读性