### PR TITLE
docs: 更新日期格式为更标准的格式

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -8,8 +8,8 @@ since = 2017
 customText = '<a href="https://debuginn.com">主页</a>&nbsp;·&nbsp<a href="https://blog.debuginn.com/">博客</a>&nbsp;·&nbsp<a href="https://photo.debuginn.com">摄影</a>&nbsp;·&nbsp<a href="/project/">项目</a>&nbsp;·&nbsp<a href="/about/">关于</a>'
 
 [dateFormat]
-published = "2023-10-15"
-lastUpdated = "2023-10-15 15:04 MST"
+published = "Jan 02, 2006"
+lastUpdated = "Jan 02, 2006 15:04 MST"
 
 [sidebar]
 emoji = "🌏"


### PR DESCRIPTION
将`published`和`lastUpdated`日期格式从"2023-10-15"和"2023-10-15 15:04 MST"更改为更标准的"Jan 02, 2006"和"Jan 02, 2006 15:04 MST"，以提高可读性和一致性。