### PR TITLE
refactor: 移除广告相关代码以简化页面结构

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -49,9 +49,6 @@ type = "archives"
 [widgets.homepage.params]
 limit = 2
 
-[[widgets.homepage]]
-type = "ad"
-
 [[widgets.page]]
 type = "search"
 
@@ -60,9 +57,6 @@ type = "toc"
 
 [[widgets.page]]
 type = "wechat"
-
-[[widgets.page]]
-type = "ad"
 
 [opengraph.twitter]
 site = "idebuginn"

--- a/layouts/partials/footer/custom.html
+++ b/layouts/partials/footer/custom.html
@@ -1,4 +1,1 @@
-<script src="https://gcore.jsdelivr.net/gh/xiabo2/CDN@latest/fishes.js"></script>
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7167312285165454"
-     crossorigin="anonymous"></script>
 <script defer src="https://cloud.umami.is/script.js" data-website-id="fe36cfb2-8a2b-4457-a3e9-961f7d732026"></script>


### PR DESCRIPTION
移除`params.toml`中的广告组件配置以及`footer/custom.html`中的广告脚本，以简化页面结构并提升用户体验。