### PR TITLE
refactor: 调整加密货币捐赠选项顺序

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -118,16 +118,16 @@ qrcode = "https://static.debuginn.com/20250807C6FEAA.png"
 link = "/reward/"
 
 [[donation.cryptos]]
-label = "SOL"
-address = "5LupLo8NuTfC411zAPo6UZTuasoTHaueuptVyGKmsdBV"
-icon = "currency-solana"
-
-[[donation.cryptos]]
 label = "ETH"
 address = "0xd06a56704ecb1eee65abcaa3101d88e2a8225a4e"
 donate = true
 amount = 0.001
 icon = "currency-ethereum"
+
+[[donation.cryptos]]
+label = "SOL"
+address = "5LupLo8NuTfC411zAPo6UZTuasoTHaueuptVyGKmsdBV"
+icon = "currency-solana"
 
 [promote]
 title = "推广"


### PR DESCRIPTION
将SOL选项移至ETH选项之后，保持配置文件的逻辑一致性