### PR TITLE
fix(广告样式): 修复广告容器高度和显示问题

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -602,6 +602,8 @@
 
     // 确保广告内容不会突破容器
     .adsbygoogle {
+        display: block;
+        height: auto;
         max-width: 100%;
         width: 100% !important;
         height: 100%;

--- a/layouts/partials/widget/ad.html
+++ b/layouts/partials/widget/ad.html
@@ -10,7 +10,7 @@
     </h2>
     <div class="stack-widget-ad-card">
         <!-- ad-style-1 -->
-        <ins class="adsbygoogle" style="display:block; max-width:100%; width:100%; height:auto;"
+        <ins class="adsbygoogle"
             data-ad-client="ca-pub-7167312285165454" data-ad-slot="3692601567" data-ad-format="auto"
             data-full-width-responsive="true"></ins>
     </div>


### PR DESCRIPTION
移除内联样式并统一在SCSS中定义广告容器样式，确保广告内容正确显示且不突破容器