### PR TITLE
fix: RSS 封面图适配 Stack v4 helper/image API

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -42,9 +42,9 @@
         {{ with .Site.Params.Author.email }}<author>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</author>{{end}}
         <guid>{{ .Permalink }}</guid>
         <description>
-            {{- $image := partial "helper/image" (dict "Context" . "Type" "rss") -}}
-            {{- if and $image $image.exists -}}
-                {{ "<" | html }}img src="{{ $image.permalink | absURL }}" alt="Featured image of post {{ .Title }}" {{ "/>" | html}}
+            {{- $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources) -}}
+            {{- if $image -}}
+                {{ "<" | html }}img src="{{ $image.Permalink | absURL }}" alt="Featured image of post {{ .Title }}" {{ "/>" | html}}
             {{- end -}}{{ $content }}{{ "<hr/>" | html }}{{ "<p>" | html }}关注微信公众号，第一时间获取最新内容，让我们一起变得更强！{{ "</p>" | html }}{{ "<p>" | html }}{{ "<" | html }}img src="https://static.debuginn.com/20241111FZS0zY.png" alt="wechat" {{ "/>" | html }}{{ "</p>" | html }}{{ "<p>" | html }}{{ "<strong>" | html }}Debug客栈：{{ "</strong>" | html }}{{- range $index, $element := .Site.Menus.main -}}{{- if $index -}} · {{ end -}}{{ "<" | html }}a href="{{ .URL | absURL }}"{{ ">" | html }}{{ .Name }}{{ "</a>" | html }}{{- end -}}{{ "</p>" | html }}
         </description>
         </item>


### PR DESCRIPTION
v3 的 helper/image 接收 (Context, Type) 参数，v4 改为 (Image, Resources)。 RSS 模板还在用 v3 的调用方式，导致封面图永远不被插入到 description 中。