### PR TITLE
chore: upgrade hugo-theme-stack v4.0.0-beta.5 → v4.0.2

### DIFF
--- a/assets/jsconfig.json
+++ b/assets/jsconfig.json
@@ -3,7 +3,7 @@
   "baseUrl": ".",
   "paths": {
    "*": [
-    "../../../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/!cai!jimmy/hugo-theme-stack/v3@v3.30.0/assets/*"
+    "../../../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/!cai!jimmy/hugo-theme-stack/v4@v4.0.0-beta.5/assets/*"
    ]
   }
  }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/CaiJimmy/hugo-theme-stack-starter
 
 go 1.17
 
-require (
-	github.com/CaiJimmy/hugo-theme-stack/v4 v4.0.0-beta.5 // indirect
-)
+require github.com/CaiJimmy/hugo-theme-stack/v4 v4.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/CaiJimmy/hugo-theme-stack/v4 v4.0.0-beta.5 h1:CezJinFPotrNCrOla1qsZEe5YlO8zEzzNYViCAIFLvA=
-github.com/CaiJimmy/hugo-theme-stack/v4 v4.0.0-beta.5/go.mod h1:6SWZIQIut6uVjxhLraexYzgtdNDrod0xnfM/to6D/1I=
+github.com/CaiJimmy/hugo-theme-stack/v4 v4.0.2 h1:q9cWu6ZS4wSesFjIjpIPueKaRmD7IoRFMGzvwZSqaBA=
+github.com/CaiJimmy/hugo-theme-stack/v4 v4.0.2/go.mod h1:6SWZIQIut6uVjxhLraexYzgtdNDrod0xnfM/to6D/1I=


### PR DESCRIPTION
Changes:
- fix: Hugo language related deprecation (v0.158.0+)
- fix: Firefox fallback breaks right-edge fade in related content
- fix: correct permalink handling for images in static folder (v4.0.1)
- Various other fixes from v4.0.0-beta.5 to v4.0.2

Note: Requires Hugo 0.157.0+ (CI uses latest, so no issue)