### PR TITLE
fix: languageCode deprecation + increase build timeout

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,6 +1,9 @@
 # Change baseurl before deploy
 baseurl = "https://blog.debuginn.com"
-languageCode = "zh"
+locale = "zh"
+
+# Remote image fetching timeout (default 60s too short for CDN)
+timeout = "300s"
 title = "Debug客栈"
 
 # Theme i18n support


### PR DESCRIPTION
- Replace deprecated languageCode with locale (Hugo v0.158.0+)
- Increase timeout to 300s to handle slow remote image fetching